### PR TITLE
Only run the CI on a PR _or_ a push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,11 @@
 
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   licenses:


### PR DESCRIPTION
This should mean that we don't see double CI runs on PRs any more