### PR TITLE
Update UCL information in `groups.toml`

### DIFF
--- a/groups.toml
+++ b/groups.toml
@@ -306,8 +306,8 @@ lon = -3.879405
 [university-college-london]
 name = "University College London"
 head = "Jonathan Cooper"
-website = "http://www.ucl.ac.uk/research-it-services/research-software-development"
-email = "rc-softdev@ucl.ac.uk"
+website = "https://www.ucl.ac.uk/advanced-research-computing/research-software-engineers"
+email = "arc.collaborations@ucl.ac.uk"
 phone = "020 310 86297"
 postcode = "WC1E 6BT"
 lat = 51.523569


### PR DESCRIPTION
Update website URL and email address for UCL group which is now part of [UCL Advanced Research Computing Centre](https://www.ucl.ac.uk/advanced-research-computing/advanced-research-computing-centre).

I've put the email address of the [Collaborations team](https://www.ucl.ac.uk/advanced-research-computing/collaborations-and-consultancy) as this has replaced the previous rc-softdev@ucl.ac.uk address, though the Collaborations team technically covers a wider range of research technology professionals than just research software engineers. @jonc125 may be able to clarify if there is a more appropriate RSE specific email address (and also check if the URL I've used is the most appropriate!).