### PR TITLE
Update Head of RSE Sheffield

### DIFF
--- a/groups.toml
+++ b/groups.toml
@@ -236,7 +236,7 @@ lon = -0.945636
 
 [sheffield]
 name = "The University of Sheffield"
-head = "Paul Richmond"
+head = "Romain Thomas"
 website = "http://rse.shef.ac.uk"
 email = "rse@sheffield.ac.uk"
 twitter = "RSE_Sheffield"


### PR DESCRIPTION
Paul Richmond left as head at the start of 2023, and Romain Thomas took over late August 2023.