### PR TITLE
Update Head of RSE Leeds

### DIFF
--- a/groups.toml
+++ b/groups.toml
@@ -168,9 +168,9 @@ lon = -0.118018
 
 [leeds]
 name = "University of Leeds"
-head = "Martin Callaghan"
+head = "Patricia Ternes"
 website = "https://arc.leeds.ac.uk"
-email = "m.callaghan@leeds.ac.uk"
+email = "p.ternesdallagnollo@leeds.ac.uk"
 postcode = "LS2 9JT"
 lat = 53.807958
 lon = -1.553329


### PR DESCRIPTION
Martin Callaghan left as head at the start of 2021, and Patricia Ternes took over January 2024.