### PR TITLE
MAP: add Scientific Software Center to the RSEGroups Map

### DIFF
--- a/groups.toml
+++ b/groups.toml
@@ -551,8 +551,8 @@ website = "https://ceh.ac.uk"
 
 [ssc-uniheidelberg]
 name = "Scientific Software Center (Universität Heidelberg)"
-head = "Inga Ulusoy/Liam Keegan/Dominic Kempf"
-website = "https://www.ssc.uni-heidelberg.de/en"
+head = "Liam Keegan/Dominic Kempf/Inga Ulusoy"
+website = "https://www.ssc.uni-heidelberg.de"
 email = "ssc@iwr.uni-heidelberg.de"
 lat = 49.41750
 lon = 8.67563

--- a/groups.toml
+++ b/groups.toml
@@ -548,3 +548,11 @@ lon = -4.132393024116693
 postcode = "LL57 2UW"
 email = "edsenquiries@ceh.ac.uk"
 website = "https://ceh.ac.uk"
+
+[ssc-uniheidelberg]
+name = "Scientific Software Center (Universität Heidelberg)"
+head = "Inga Ulusoy/Liam Keegan/Dominic Kempf"
+website = "https://www.ssc.uni-heidelberg.de/en"
+email = "ssc@iwr.uni-heidelberg.de"
+lat = 49.41750
+lon = 8.67563


### PR DESCRIPTION
**Description:** add Scientific Software Center to the RSEGroups Map

**Information:** [Scientific Software Center (Universität Heidelberg)](https://www.ssc.uni-heidelberg.de/en)


Files modified: 
- _groups.toml_