### PR TITLE
Auto-request review from trustees

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: © 2025 Society of Research Software Engineering
+# SPDX-License-Identifier: MIT
+
 # Auto-request review from the trustees group
 * @socrse/trustees

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-request review from the trustees group
+* @socrse/trustees

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) <year> <copyright holders>
+Copyright (c) 2025 Society of Research Software Engineering
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,4 @@
 RSE Groups map
 ==============
 
-If you would like to add your group or update the details, please open a PR editing ``groups.toml``.
+If you would like to add your group or update the details, please fork this repository and  open a PR editing `groups.toml`.


### PR DESCRIPTION
Should work from forks I think. The trustees group will need to have write access but I think that's reasonable. 

Also appeased the linter for licence and updated it so the MIT is valid