### PR TITLE
Fixed location of ccv.brown.edu

### DIFF
--- a/groups.toml
+++ b/groups.toml
@@ -87,7 +87,7 @@ head = "Paul Stey"
 website = "https://ccv.brown.edu"
 email = "support@ccv.brown.edu"
 lat = 41.8268
-lon = 71.4025
+lon = -71.4025
 
 [cambridge]
 name = "University of Cambridge"


### PR DESCRIPTION
The map in the homepage shows wrong location of the ccv group.